### PR TITLE
Url autotagaus

### DIFF
--- a/src/main/java/dao/AutotagDao.java
+++ b/src/main/java/dao/AutotagDao.java
@@ -1,0 +1,7 @@
+package dao;
+
+import java.util.Map;
+
+public interface AutotagDao {
+    Map<String, String> haeMappaukset();
+}

--- a/src/main/java/dao/HashMapAutotagDao.java
+++ b/src/main/java/dao/HashMapAutotagDao.java
@@ -1,0 +1,23 @@
+package dao;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class HashMapAutotagDao implements AutotagDao {
+    private Map<String, String> mappaukset;
+
+    public HashMapAutotagDao() {
+        mappaukset = Stream.of(new String[][] {
+            { "youtube", "video" }, 
+            { "dl.acm.org", "artikkeli" }, 
+            { "is.fi", "artikkeli" },
+            { "hs.fi", "artikkeli" },
+          }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+    }
+
+    @Override
+    public Map<String, String> haeMappaukset() {
+        return this.mappaukset;
+    }
+}

--- a/src/main/java/dao/HashMapAutotagDao.java
+++ b/src/main/java/dao/HashMapAutotagDao.java
@@ -9,10 +9,10 @@ public class HashMapAutotagDao implements AutotagDao {
 
     public HashMapAutotagDao() {
         mappaukset = Stream.of(new String[][] {
-            { "youtube", "video" }, 
-            { "dl.acm.org", "artikkeli" }, 
-            { "is.fi", "artikkeli" },
-            { "hs.fi", "artikkeli" },
+            {"youtube", "video"}, 
+            {"dl.acm.org", "artikkeli"}, 
+            {"is.fi", "artikkeli"},
+            {"hs.fi", "artikkeli" },
           }).collect(Collectors.toMap(data -> data[0], data -> data[1]));
     }
 

--- a/src/main/java/domain/Sovellus.java
+++ b/src/main/java/domain/Sovellus.java
@@ -20,12 +20,14 @@ import java.util.Map;
 public class Sovellus {
 
     private LukuvinkkiDao lukuvinkkiDao;
+    private AutotagDao autotagDao;
     private LocalDate paivamaara;
     private DateTimeFormatter pvmMuotoilu;
 
     public Sovellus(LukuvinkkiDao lukuvinkkiDao) {
         this.lukuvinkkiDao = lukuvinkkiDao;
         this.pvmMuotoilu = DateTimeFormatter.ofPattern("yyyy MM dd");
+        this.autotagDao = new HashMapAutotagDao();
     }
 
     public List<String> selaaVinkkeja() {
@@ -68,8 +70,7 @@ public class Sovellus {
     }
 
     private String autoTagaa(String linkki, String tagit) {
-        AutotagDao autoTag = new HashMapAutotagDao();
-        Map<String, String> mappaukset = autoTag.haeMappaukset();
+        Map<String, String> mappaukset = autotagDao.haeMappaukset();
         for (String sivusto : mappaukset.keySet()) {
             if (linkki.contains(sivusto) && !tagit.contains(mappaukset.get(sivusto))) {
                 tagit += (tagit.isEmpty()) ? mappaukset.get(sivusto) : "," + mappaukset.get(sivusto);

--- a/src/main/java/domain/Sovellus.java
+++ b/src/main/java/domain/Sovellus.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dao.AutotagDao;
-import dao.HashMapAutotagDao;
 import dao.LukuvinkkiDao;
 import domain.suodatus.Ehto;
 import domain.suodatus.Kaikki;
@@ -24,10 +23,10 @@ public class Sovellus {
     private LocalDate paivamaara;
     private DateTimeFormatter pvmMuotoilu;
 
-    public Sovellus(LukuvinkkiDao lukuvinkkiDao) {
+    public Sovellus(LukuvinkkiDao lukuvinkkiDao, AutotagDao autotagDao) {
         this.lukuvinkkiDao = lukuvinkkiDao;
         this.pvmMuotoilu = DateTimeFormatter.ofPattern("yyyy MM dd");
-        this.autotagDao = new HashMapAutotagDao();
+        this.autotagDao = autotagDao;
     }
 
     public List<String> selaaVinkkeja() {

--- a/src/main/java/domain/Sovellus.java
+++ b/src/main/java/domain/Sovellus.java
@@ -4,6 +4,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
+import dao.AutotagDao;
+import dao.HashMapAutotagDao;
 import dao.LukuvinkkiDao;
 import domain.suodatus.Ehto;
 import domain.suodatus.Kaikki;
@@ -56,9 +59,21 @@ public class Sovellus {
     }
 
     public void lisaaVinkki(String otsikko, String linkki, String tagit, String paivamaara) {
+        tagit = autoTagaa(linkki, tagit.replaceAll("\\s|;", ""));
         Vinkki vinkki = new Oletus(otsikko.trim().replaceAll(";", ":"), linkki.trim().replaceAll(";", ":"),
-                tagit.replaceAll("\\s|;", ""), paivamaara);
+                tagit, paivamaara);
         lukuvinkkiDao.lisaa(vinkki);
+    }
+
+    private String autoTagaa(String linkki, String tagit) {
+        AutotagDao autoTag = new HashMapAutotagDao();
+        Map<String, String> mappaukset = autoTag.haeMappaukset();
+        for (String sivusto : mappaukset.keySet()) {
+            if (linkki.contains(sivusto) && !tagit.contains(mappaukset.get(sivusto))) {
+                tagit += (tagit.isEmpty()) ? mappaukset.get(sivusto) : "," + mappaukset.get(sivusto);
+            } 
+        }
+        return tagit;
     }
 
     public void merkitseLuetuksi(int indeksi) {

--- a/src/main/java/lukuvinkkikirjasto/Main.java
+++ b/src/main/java/lukuvinkkikirjasto/Main.java
@@ -24,8 +24,9 @@ public class Main {
         String usedFile = properties.getProperty("testFile");
 
         LukuvinkkiDao lukuvinkkiDao = new FileLukuvinkkiDao(new File(usedFile));
+        AutotagDao autotagDao = new HashMapAutotagDao();
         
-        Sovellus sovellus = new Sovellus(lukuvinkkiDao);
+        Sovellus sovellus = new Sovellus(lukuvinkkiDao, autotagDao);
         TextUI kayttoliittyma = new TextUI(textIO, sovellus, urlService);
 
         kayttoliittyma.suorita();

--- a/src/test/java/domain/SovellusTest.java
+++ b/src/test/java/domain/SovellusTest.java
@@ -1,6 +1,8 @@
 package domain;
 
+import dao.AutotagDao;
 import dao.FileLukuvinkkiDao;
+import dao.HashMapAutotagDao;
 import dao.LukuvinkkiDao;
 
 import static org.junit.Assert.assertEquals;
@@ -20,12 +22,14 @@ import org.mockito.Mockito;
 
 public class SovellusTest {
     LukuvinkkiDao mockDao;
+    AutotagDao autotagDao;
     Sovellus testiSovellus;
 
     @Before
     public void setUp() {
         mockDao = mock(FileLukuvinkkiDao.class);
-        testiSovellus = new Sovellus(mockDao);
+        autotagDao = new HashMapAutotagDao();
+        testiSovellus = new Sovellus(mockDao, autotagDao);
     }
     /*
     @Test

--- a/src/test/java/lukuvinkkikirjasto/Stepdefs.java
+++ b/src/test/java/lukuvinkkikirjasto/Stepdefs.java
@@ -1,6 +1,8 @@
 package lukuvinkkikirjasto;
 
+import dao.AutotagDao;
 import dao.FileLukuvinkkiDao;
+import dao.HashMapAutotagDao;
 import domain.*;
 import domain.Sovellus;
 import io.cucumber.java.Before;
@@ -33,6 +35,7 @@ public class Stepdefs {
     File tiedosto;
     StubIO io;
     FileLukuvinkkiDao lukuvinkit;
+    AutotagDao autotagDao;
     List<String> syoterivit;
     TextUI ui;
     
@@ -46,9 +49,10 @@ public class Stepdefs {
         }
         lukuvinkit = new FileLukuvinkkiDao(tiedosto);
         lukuvinkit.lisaa(new Oletus("Testiotsikko", "Testilinkki", "Testitägi", "null"));
+        autotagDao = new HashMapAutotagDao();
         syoterivit = new ArrayList<>();
         io = new StubIO(syoterivit);
-        app = new Sovellus(lukuvinkit);
+        app = new Sovellus(lukuvinkit, autotagDao);
         // TODO tälle pitää tehdä stub
         UrlDataService urlService = new UrlDataServiceStub();
         ui = new TextUI(io, app, urlService);
@@ -250,5 +254,24 @@ public class Stepdefs {
             }
         }
         assertTrue(uusimmanOtsikonIndeksi < toiseksiUusimmanOtsikonIndeksi);
+    }
+
+    @Then("lisatyn vinkin tageista loytyy {string}") 
+    public void tarkistaTagi(String tagi) {
+        io.lisaaSyote("1");
+        io.lisaaSyote("-1");
+        ui.suorita();
+        List<String> tulosteet = io.getTulosteet();
+        assertTrue(tulosteet.get(tulosteet.size() - 4).contains(tagi));
+    }
+
+    @Then("lisatyn vinkin tagit ovat {string}") 
+    public void tarkistaVinkinKaikkiTagit(String tagit) {
+        io.lisaaSyote("1");
+        io.lisaaSyote("-1");
+        ui.suorita();
+        List<String> tulosteet = io.getTulosteet();
+        assertTrue(tulosteet.get(tulosteet.size() - 4).contains(tagit));
+        assertFalse(tulosteet.get(tulosteet.size() - 4).contains(tagit + "#video"));
     }
 }

--- a/src/test/resources/lukuvinkkikirjasto/automaattinentagaus.feature
+++ b/src/test/resources/lukuvinkkikirjasto/automaattinentagaus.feature
@@ -1,0 +1,15 @@
+Feature: Sovellus lisaa tagin automaattisesti linkin perusteella
+
+    Scenario: Sovellus tagaa automaatisesti videolinkin
+        Given kayttaja kertoo haluavansa lisata vinkin
+        When  kayttaja kirjoittaa "https://www.youtube.com/watch?v=i3NRe3KulqU"
+        And   kayttaja kirjoittaa ""
+        And   kayttaja kirjoittaa "smb, wr, 4:54"
+        Then  lisatyn vinkin tageista loytyy "video"
+
+    Scenario: Sovellus ei lisaa tagia, jos kayttaja on jo antanut vinkille saman tagin
+        Given kayttaja kertoo haluavansa lisata vinkin
+        When  kayttaja kirjoittaa "https://www.youtube.com/watch?v=i3NRe3KulqU"
+        And   kayttaja kirjoittaa ""
+        And   kayttaja kirjoittaa "smb, video, 4:54"
+        Then  lisatyn vinkin tagit ovat "#smb #video #4:54"

--- a/src/test/resources/lukuvinkkikirjasto/suodatettulistaus.feature
+++ b/src/test/resources/lukuvinkkikirjasto/suodatettulistaus.feature
@@ -30,7 +30,7 @@ Feature: Kayttaja suodattaa vinkkeja
     Given vinkki "loisto", URL "muu.com" ja tagi "paras,jep,jee" on listalla
     And vinkki "paras", URL "maa.com" ja tagi "paras,maa,jee" on listalla
     And kayttaja kertoo haluavansa etsia vinkkeja tagilla
-    When  kayttaja antaa tagin "paras ja jep ja jee"
+    When  kayttaja kirjoittaa "paras ja jep ja jee"
     And   annetaan lopetuskomento
     Then  listauksesta loytyy vinkki "Vinkki: loisto" ja linkki "muu.com"
     Then  listauksesta ei loydy vinkkia "paras" ja linkkia "maa.com"


### PR DESCRIPTION
Karvalakkitoteutus urlin perusteella tagauksesta. Tätä voi laajentaa melko helposti, mutta perustoiminnalisuus toteutuu hyväksymiskriteerien osalta. Jos tämä on mielestänne ok, niin kommentoikaa tänne ennen mergeä, jotta voin injektoida mappaukset sisältävän dao:n Sovellus.java:lle konstruktorissa ja korjata sen rikkomat testit.